### PR TITLE
Feature/bip143

### DIFF
--- a/CoreBitcoin.podspec
+++ b/CoreBitcoin.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "CoreBitcoin"
-  s.version      = "0.7.0.1"
+  s.version      = "0.7.0.2"
   s.summary      = "CoreBitcoin is an implementation of Bitcoin protocol in Objective-C."
   s.description  = <<-DESC
                    CoreBitcoin is a complete toolkit to work with Bitcoin data structures.
                    DESC
-  s.homepage     = "https://github.com/oleganza/CoreBitcoin"
+  s.homepage     = "https://github.com/usatie/CoreBitcoin"
   s.license      = 'WTFPL'
-  s.author       = { "Oleg Andreev" => "oleganza@gmail.com" }
+  s.author       = { "Shun Usami" => "usatie@mikan.link" }
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
   s.source       = { :git => "https://github.com/usatie/CoreBitcoin.git", :tag => s.version.to_s }

--- a/CoreBitcoin/BTCOutpoint.h
+++ b/CoreBitcoin/BTCOutpoint.h
@@ -15,6 +15,9 @@
 // Index of the previous transaction's output.
 @property(nonatomic) uint32_t index;
 
+// tx_id_hash + index
+@property(nonatomic) NSData* data;
+
 - (id) initWithHash:(NSData*)hash index:(uint32_t)index;
 
 - (id) initWithTxID:(NSString*)txid index:(uint32_t)index;

--- a/CoreBitcoin/BTCOutpoint.m
+++ b/CoreBitcoin/BTCOutpoint.m
@@ -33,6 +33,12 @@
     return words[0] + self.index;
 }
 
+- (NSData*) data {
+    NSMutableData* payload = [NSMutableData dataWithData:self.txHash];
+    [payload appendBytes:&_index length:4];
+    return payload;
+}
+
 - (BOOL) isEqual:(BTCOutpoint*)object {
     return [self.txHash isEqual:object.txHash] && self.index == object.index;
 }

--- a/CoreBitcoin/BTCTransaction.h
+++ b/CoreBitcoin/BTCTransaction.h
@@ -126,6 +126,7 @@ NSString* BTCTransactionIDFromHash(NSData* txhash) DEPRECATED_ATTRIBUTE;
 
 // Hash for signing a transaction.
 // You should supply the output script of the previous transaction, desired hash type and input index in this transaction.
+- (NSData*) signatureHashForScript:(BTCScript*)subscript inputIndex:(uint32_t)inputIndex hashType:(BTCSignatureHashType)hashType amount:(BTCAmount)amount error:(NSError **)errorOut;
 - (NSData*) signatureHashForScript:(BTCScript*)subscript inputIndex:(uint32_t)inputIndex hashType:(BTCSignatureHashType)hashType error:(NSError**)errorOut;
 
 // Adds input script


### PR DESCRIPTION
# 概要
BitcoinCashはBIP143に沿っているため、その実装。
具体的にはトランザクションダイジェストアルゴリズムの変更。
以下の(Tx digest)の部分のアルゴリズムの変更。

[tx]---(Tx digest)--->[serialized tx]---(SAH256^2)--->[hashed tx]---(key sign)--->[signed tx] 

## 参考
BIP143
https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki